### PR TITLE
Adding missing param for server side c_pong parity function in network clock.

### DIFF
--- a/ep2/serverProject/script/network/network_clock.gd
+++ b/ep2/serverProject/script/network/network_clock.gd
@@ -45,7 +45,7 @@ func s_ping(echoClientClockMs:int, echoClientTick:int):
 #region RPC PARITY
 
 
-@rpc("reliable") func c_pong(echoClientTick:int, echoClientClockMs:int): pass
+@rpc("reliable") func c_pong(serverTick:int, echoClientTick:int, echoClientClockMs:int): pass
 
 
 #endregion RPC FUNCTIONS


### PR DESCRIPTION
There was a missing parameter in the RPC parity c_pong function in the server project. If I'm wrong (pretty new to this), let me know and I'll abandon the PR.